### PR TITLE
INFRA-3734 Support headers with the amqp output

### DIFF
--- a/libbeat/outputs/amqp/amqp.go
+++ b/libbeat/outputs/amqp/amqp.go
@@ -100,6 +100,7 @@ func makeAMQP(
 			routingKeySelector,
 			config.PersistentDeliveryMode,
 			config.ContentType,
+			config.HeadersKey,
 			config.MandatoryPublish,
 			config.ImmediatePublish,
 			config.EventPrepareConcurrency,

--- a/libbeat/outputs/amqp/amqp_integration_test.go
+++ b/libbeat/outputs/amqp/amqp_integration_test.go
@@ -32,13 +32,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/outest"
-	"github.com/streadway/amqp"
-	"github.com/stretchr/testify/assert"
 
 	_ "github.com/elastic/beats/libbeat/outputs/codec/format"
 	_ "github.com/elastic/beats/libbeat/outputs/codec/json"

--- a/libbeat/outputs/amqp/client.go
+++ b/libbeat/outputs/amqp/client.go
@@ -22,10 +22,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/elastic/beats/libbeat/common"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/elastic/beats/libbeat/common/backoff"
 	"github.com/elastic/beats/libbeat/publisher"

--- a/libbeat/outputs/amqp/config.go
+++ b/libbeat/outputs/amqp/config.go
@@ -36,6 +36,7 @@ type amqpConfig struct {
 	ExchangeDeclare         exchangeDeclareConfig `config:"exchange_declare"`
 	PersistentDeliveryMode  bool                  `config:"persistent_delivery_mode"`
 	ContentType             string                `config:"content_type"`
+	HeadersKey              string                `config:"headers_key"`
 	MandatoryPublish        bool                  `config:"mandatory_publish"`
 	ImmediatePublish        bool                  `config:"immediate_publish"`
 	BulkMaxSize             int                   `config:"bulk_max_size" validate:"min=1"`


### PR DESCRIPTION
### What?
Does what the tile says.

### Why?
So we can use filebeat-amqp as a drop-in replacement of any generic RabbitMQ driver. i.e. instead of publishing messages directly to RabbitMQ, we can have a driver that writes to a local file as a buffer before using filebeat-amqp to ship the events to RabbitMQ. 


### Tests

This was tested manually with the following config

#### /etc/filebeat_webhooks/filebeat.yml

```yaml
root@yvonneparticipat-cloud-dev-vm:/etc/filebeat_webhooks# cat /etc/filebeat_webhooks/filebeat.yml
### Filebeat configuration managed by Puppet ###

filebeat.inputs:
    # App logs - prospector
    - type: log
      json:
        add_error_key: true
      paths:
        - "/var/cache/bc/mq/webhooks/events.log"


registry.path: "/var/lib/filebeat_webhooks/registry"

output.amqp:
  hosts: ["amqp://root:magic@rmq.service.consul:5672/webhooks"]
  exchange: "%{[json.exchange]:events}"
  routing_key: "%{[json.topic]}"
  headers_key: "json.headers"
  exchange_declare: # when the amqp output needs to dynamically declare an exchange it will use this config
    enabled: true
    kind: "topic"
    durable: true
    auto_delete: false
  persistent_delivery_mode: true
  mandatory_publish: false
  bulk_max_size: 2048
  pending_publish_buffer_size: 2048
  max_retries: 5
  codec.format:
    string: "%{[json.message]}"

shipper: {}
logging:
  to_syslog: true
  level: "debug"
  selectors: "*"
  metrics:
    enabled: true
    period: "60s"
runoptions: {}
processors: []
setup: {}
http.enabled: true
http.port: 6070
http.host: "127.0.0.1"
xpack: !ruby/sym undef
```

#### The Payload
```json
{
  "topic": "events.10003463.store-product-created",
  "exchange": "events",
  "message": "{\"created_at\":1594886857,\"producer\":\"stores\\/msw3rey8hc\",\"store_id\":10003463,\"store_hash\":\"msw3rey8hc\",\"scope\":\"store\\/product\\/created\",\"data\":{\"type\":\"product\",\"id\":111},\"hash\":\"9d437d895d9268d12728fcb68a9bb8ae519f8e74\"}",
  "headers": {
    "content-type": "application/grpc+json"
  }
}
```

#### Published Results
![image](https://user-images.githubusercontent.com/357672/87645715-36b15c80-c791-11ea-88d7-2c6c6b2f2119.png)

Note: message 2 was published directly to rabbitmq while message 3 was published via filebeat-amqp.

ping @gwilym @rayward @bigcommerce/technical-operations 
