### PR TITLE
Allow headers to be missing for amqp outputs

### DIFF
--- a/libbeat/outputs/amqp/amqp_integration_test.go
+++ b/libbeat/outputs/amqp/amqp_integration_test.go
@@ -226,6 +226,20 @@ func TestAMQPPublish(t *testing.T) {
 			},
 		},
 		{
+			"single event to selected exchange with missing headers",
+			map[string]interface{}{
+				"exchange":    "%{[foo]}",
+				"headers_key": "headers",
+			},
+			testExchange + "-select",
+			testRoutingKey,
+			single(common.MapStr{
+				"foo":        testExchange + "-select",
+				messageField: id,
+			}),
+			nil,
+		},
+		{
 			"single event to selected exchange ignoring headers",
 			map[string]interface{}{
 				"exchange": "%{[foo]}",

--- a/libbeat/outputs/amqp/client.go
+++ b/libbeat/outputs/amqp/client.go
@@ -510,6 +510,12 @@ func (c *client) getHeaders(content *beat.Event) (amqp.Table, error) {
 	c.logger.Debugf("using headers key: %v", c.headersKey)
 
 	value, err := content.Fields.GetValue(c.headersKey)
+
+	// Allowing headers to be missing
+	if err == common.ErrKeyNotFound {
+		return nil, nil
+	}
+
 	if err != nil {
 		c.logger.Debugf("error fetch headers with key %v: %v", c.headersKey, err)
 		return nil, err


### PR DESCRIPTION
It should be a legit case where `headers_key` is specified but `headers` is unspecified. I didn't realise the issue because my tests earlier were all against the version where errors in `getHeaders()` were silenced. 

ping @gwilym @rayward 