### PR TITLE
AMQP output: handle dropped events correctly

### DIFF
--- a/libbeat/outputs/amqp/amqp_integration_test.go
+++ b/libbeat/outputs/amqp/amqp_integration_test.go
@@ -273,6 +273,9 @@ func TestAMQPPublish(t *testing.T) {
 			map[string]interface{}{
 				"exchange":    "%{[exchange]}",
 				"routing_key": "%{[routing_key]}",
+				"codec.format": map[string]string{
+					"string": "%{[message]}",
+				},
 			},
 			testExchange + "-select",
 			testRoutingKey + "-select",
@@ -284,21 +287,21 @@ func TestAMQPPublish(t *testing.T) {
 							Fields: common.MapStr{
 								"exchange":    testExchange + "-select",
 								"routing_key": testRoutingKey + "-select",
-								messageField:  id,
+								messageField:  "{\"message\": \"hello\"}",
 							},
 						},
 						{
 							Timestamp: time.Now(),
 							Fields: common.MapStr{
 								"routing_key": testRoutingKey + "-select",
-								messageField:  "no exchange key",
+								"error":       "Error decoding JSON",
 							},
 						},
 						{
 							Timestamp: time.Now(),
 							Fields: common.MapStr{
-								"exchange":   testExchange + "-select",
-								messageField: "no routing key",
+								"exchange": testExchange + "-select",
+								"error":    "Error decoding JSON",
 							},
 						},
 						{
@@ -306,14 +309,14 @@ func TestAMQPPublish(t *testing.T) {
 							Fields: common.MapStr{
 								"exchange":    testExchange + "-select",
 								"routing_key": testRoutingKey + "-select",
-								messageField:  id,
+								messageField:  "{\"message\": \"hello\"}",
 							},
 						},
 					},
 				},
 			},
 			nil,
-			2,
+			2, // Expecting the two valid events to be published only
 		},
 	}
 

--- a/libbeat/outputs/amqp/batchtracker.go
+++ b/libbeat/outputs/amqp/batchtracker.go
@@ -133,7 +133,7 @@ func (b *batchTracker) finalize() {
 		return
 	}
 
-	b.logger.Debugf("batch completed successfully")
+	b.logger.Debugf("batch completed successfully, %v dropped, %v in total", b.dropped, b.counter)
 	b.batch.ACK()
 	b.observer.Dropped(int(b.dropped))
 	b.observer.Acked(int(b.counter - b.dropped))

--- a/libbeat/outputs/amqp/batchtracker.go
+++ b/libbeat/outputs/amqp/batchtracker.go
@@ -77,7 +77,7 @@ type batchTracker struct {
 	// dropped is the count of dropped events
 	dropped uint64
 
-	// observer
+	// observer is the interface used by outputs to report common events
 	observer outputs.Observer
 }
 

--- a/libbeat/outputs/amqp/client.go
+++ b/libbeat/outputs/amqp/client.go
@@ -464,17 +464,11 @@ func (c *client) prepareEvent(codec codec.Codec, incoming eventTracker, now time
 	if err != nil {
 		return nil, fmt.Errorf("exchange select: %v", err)
 	}
-	if exchangeName == "" {
-		return nil, fmt.Errorf("exchange name is missing")
-	}
 	c.logger.Debugf("calculated exchange name: %v", exchangeName)
 
 	routingKey, err := c.routingKeySelector.Select(content)
 	if err != nil {
 		return nil, fmt.Errorf("routing key select: %v", err)
-	}
-	if routingKey == "" {
-		return nil, fmt.Errorf("routing key is missing")
 	}
 	c.logger.Debugf("calculated routing key: %v", routingKey)
 

--- a/libbeat/outputs/amqp/client.go
+++ b/libbeat/outputs/amqp/client.go
@@ -230,7 +230,7 @@ func (c *client) Publish(batch publisher.Batch) error {
 
 	// Start tracking this batch and put all of its events into the incoming
 	// events queue.
-	batchTracker := newBatchTracker(batch, c.logger)
+	batchTracker := newBatchTracker(batch, c.observer, c.logger)
 	for _, event := range batch.Events() {
 		c.incomingEvents <- newEventTracker(batchTracker, event)
 	}
@@ -317,6 +317,7 @@ func (c *client) handleIncomingEvents(ctx context.Context, workerId uint64, enco
 		prepared, err := c.prepareEvent(encoder, incomingEvent, time.Now)
 		if err != nil {
 			c.logger.Errorf("event dropped: %v", err)
+			incomingEvent.batchTracker.dropEvent()
 			continue
 		}
 

--- a/libbeat/outputs/amqp/client.go
+++ b/libbeat/outputs/amqp/client.go
@@ -464,11 +464,17 @@ func (c *client) prepareEvent(codec codec.Codec, incoming eventTracker, now time
 	if err != nil {
 		return nil, fmt.Errorf("exchange select: %v", err)
 	}
+	if exchangeName == "" {
+		return nil, fmt.Errorf("exchange name is missing")
+	}
 	c.logger.Debugf("calculated exchange name: %v", exchangeName)
 
 	routingKey, err := c.routingKeySelector.Select(content)
 	if err != nil {
 		return nil, fmt.Errorf("routing key select: %v", err)
+	}
+	if routingKey == "" {
+		return nil, fmt.Errorf("routing key is missing")
 	}
 	c.logger.Debugf("calculated routing key: %v", routingKey)
 


### PR DESCRIPTION
Events were dropped without notifying the amqp `batchTracker`. As a result, any batch with an invalid event won't be finalized, causing the whole pipleline to be blocked. This PR addresses the issue by supporting `dropEvent` in `batchTracker`. Also, dropped events are now reported with the output observer for monitoring purposes. 

~Additionally, events without an exchange name or routing key are dropped now, since they won't work anyway.~

### Tests

#### Integration tests
![image](https://user-images.githubusercontent.com/357672/93167747-9d88cd00-f764-11ea-8b8a-38601e6f409a.png)

#### Manual tests
Verified that metrics are reported correctly
```
      "events": {
        "acked": 1,
        "active": 0,
        "batches": 4,
        "dropped": 3,
        "duplicates": 0,
        "failed": 0,
        "toomany": 0,
        "total": 4
      },
```

Review please. ping @gwilym @rayward 



